### PR TITLE
Fix: custom encrypted pin in creating transfers

### DIFF
--- a/lib/mixin_bot/api/transfer.rb
+++ b/lib/mixin_bot/api/transfer.rb
@@ -9,12 +9,13 @@ module MixinBot
         amount = options[:amount]
         memo = options[:memo]
         trace_id = options[:trace_id] || SecureRandom.uuid
+        encrypted_pin = options[:encrypted_pin] || encrypt_pin(pin)
 
         path = '/transfers'
         payload = {
           asset_id: asset_id,
           opponent_id: opponent_id,
-          pin: encrypt_pin(pin),
+          pin: encrypted_pin,
           amount: amount.to_s,
           trace_id: trace_id,
           memo: memo


### PR DESCRIPTION
To be compatible with other Mixin SDKs, such as the Golang SDK, accept a custom encrypted pin. This is useful when the actual iterators in the network are already greater than the default iterator in this Ruby SDK.