### PR TITLE
[lean-squad] 🔬 [lean-squad] Research & target identification + Lean CI scaffold

### DIFF
--- a/.github/workflows/lean-ci.yml
+++ b/.github/workflows/lean-ci.yml
@@ -1,0 +1,77 @@
+name: Lean CI
+
+# 🔬 Lean Squad — verifies Lean 4 proofs in formal-verification/lean/.
+#
+# This workflow only activates when Lean source files are touched or the
+# workflow file itself is updated. The first PR that adds .lean files will
+# also need to add `formal-verification/lean/lean-toolchain` (e.g.
+# `leanprover/lean4:stable`) so `elan toolchain install` below succeeds.
+
+on:
+  pull_request:
+    paths:
+      - 'formal-verification/lean/**'
+      - '.github/workflows/lean-ci.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'formal-verification/lean/**'
+      - '.github/workflows/lean-ci.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Verify Lean Proofs
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: formal-verification/lean
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install elan
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+            | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+      - name: Install Lean toolchain
+        run: elan toolchain install $(cat lean-toolchain)
+
+      - name: Show Lean version
+        run: lean --version
+
+      - name: Compute cache key
+        id: cache-key
+        run: echo "manifest_hash=$(sha256sum lake-manifest.json | cut -c1-16)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache .lake build artefacts
+        uses: actions/cache@v4
+        with:
+          path: formal-verification/lean/.lake
+          key: lean-lake-${{ steps.cache-key.outputs.manifest_hash }}
+          restore-keys: lean-lake-
+
+      - name: Resolve dependencies (lake update)
+        run: lake update
+
+      - name: Build and verify all proofs
+        run: |
+          mkdir -p /tmp/gh-aw/agent
+          echo "=== lake build starting ==="
+          lake build 2>&1 | tee /tmp/gh-aw/agent/lake_build.log
+          BUILD_EXIT=${PIPESTATUS[0]}
+          SORRY_COUNT=$(grep -c 'sorry' /tmp/gh-aw/agent/lake_build.log || true)
+          echo ""
+          echo "=== lake build exit code: $BUILD_EXIT ==="
+          echo "=== 'sorry' occurrences in build output: $SORRY_COUNT ==="
+          exit $BUILD_EXIT
+
+      - name: Upload build log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lake-build-log
+          path: /tmp/gh-aw/agent/lake_build.log

--- a/formal-verification/RESEARCH.md
+++ b/formal-verification/RESEARCH.md
@@ -1,0 +1,120 @@
+# Formal Verification Research — MixinBot
+
+> 🔬 *Lean Squad — automated formal verification for `baizhiheizi/mixin_bot`.*
+
+**Status**: Research phase complete; targets identified; ready for informal spec extraction.
+
+## 1. Codebase Survey
+
+MixinBot is a Ruby gem (v2.2.1) that provides a REST SDK + CLI for the
+[Mixin Network](https://developers.mixin.one/docs). It mirrors the official
+[bot-api-go-client](https://github.com/MixinNetwork/bot-api-go-client) and
+[bot-api-nodejs-client](https://github.com/MixinNetwork/bot-api-nodejs-client)
+SDKs. The repository contains:
+
+| Layer | Path | Notes |
+|-------|------|-------|
+| HTTP client | `lib/mixin_bot/client.rb` | Faraday-based, returns `ApiEnvelope` |
+| API domains | `lib/mixin_bot/api/*.rb` (~30 modules) | Safe + legacy variants |
+| Crypto & encoding utilities | `lib/mixin_bot/utils/` | Foundation for higher layers |
+| Transaction encoder/decoder | `lib/mixin_bot/transaction/` | Hex-format raw transactions |
+| Data structures | `lib/mixin_bot/{uuid,address,nfo,invoice,bot_auth}.rb` | Mixin-specific types |
+| CLI | `lib/mixin_bot/cli/` | Thor-based; not in scope for FV |
+| Tests | `test/` (Minitest + WebMock) | Includes golden fixtures from Go SDK |
+
+The codebase has excellent test infrastructure that doubles as **specification
+hints**: `golden_*.rb` tests pin byte-for-byte compatibility with the Go SDK
+output, and `transaction_fixture_test.rb` does the same for the on-chain
+transaction format against a real hex blob.
+
+## 2. Language/Tool Choice
+
+**Tool**: Lean 4 (with Mathlib) — chosen for its strong induction, `decide`,
+and the established Lean Squad methodology. The codebase is Ruby (not Rust),
+so the standard Aeneas/Charon pipeline (Task 8 Route A) does not apply; we
+will use **Route B** (executable correspondence tests via shared fixtures) for
+cross-validation. See [`TARGETS.md`](TARGETS.md) for per-target plans.
+
+## 3. FV-Amenability Heuristics Applied
+
+When triaging the ~25 candidates, we scored each on:
+
+- **Purity**: is the function pure / deterministic / free of I/O?
+- **Spec size**: how many Lean lines to state the key properties?
+- **Proof tractability**: `decide` / `simp` / `omega` / induction?
+- **Bug-catching potential**: security-sensitive? critical-path?
+- **Existing tests**: do existing tests give us an oracle to lean against?
+- **Reuse**: are similar invariants proved for the Go SDK (parity hint)?
+
+## 4. Identified Targets (Summary)
+
+Five targets selected. Full prioritisation in [`TARGETS.md`](TARGETS.md).
+
+| # | Target | Tier | Tractability | Key property |
+|---|--------|------|--------------|--------------|
+| 1 | `UUID.unpacked` / `packed` round-trip | T1 | high | format-preserving bijection hex ↔ binary ↔ dashed |
+| 2 | `Utils::Encoder.encode_int` ↔ `Decoder.decode_int` | T1 | high | non-negative integer varint round-trip |
+| 3 | `encode_uint16/32/64` ↔ `decode_uint16/32/64` | T1 | very high | fixed-width big-endian round-trip |
+| 4 | `MainAddress` encode/decode round-trip + invariants | T2 | high | `XIN`-prefixed, valid base58, valid SHA3-256 checksum |
+| 5 | `MixAddress` encode/decode round-trip + invariants | T2 | medium | `MIX`-prefixed, valid base58, member list + threshold preserved |
+| 6 | `Transaction` encoder/decoder round-trip | T3 | medium | golden hex fixture passes; `decode ∘ encode = id` |
+| 7 | `Nfo` (NFT memo) round-trip | T3 | medium | mask-dependent payload invariant |
+
+Targets 6 and 7 are intentionally deferred until we have proved the foundation
+(targets 1–3, used as building blocks by everything else) plus a critical-mass
+of round-trip infrastructure from target 5.
+
+## 5. Approach Notes
+
+- **Modeling style**: functional Lean 4 mirroring the imperative Ruby, using
+  `ByteArray`, `List Byte`, and bit-manipulation lemmas from Mathlib
+  (`Mathlib.Data.List.Basic`, `Mathlib.Data.ByteArray`, etc.).
+- **Abstractions**: hex strings are modeled as `String` of length 32 (no dashes)
+  or 36 (with dashes); binary blobs as `ByteArray`. The hex ↔ byte conversion
+  is modeled explicitly via `String.toByteArray`/`ByteArray.toHex`.
+- **What we explicitly abstract**: I/O, file reads, randomness, the
+  surrounding `ActiveSupport`-style helpers (`present?`, `blank?`). Models
+  are written as total functions over already-validated inputs.
+- **Validation strategy**: every proved round-trip is validated against the
+  existing golden fixtures (`test/fixtures/golden/*.json`,
+  `test/fixtures/transactions/version3_multi_io.hex`). The Lean model is run
+  through `lake build` and a Ruby harness executes the Lean model on the same
+  inputs to confirm behavioural agreement (Task 8 Route B).
+- **Proof tactics inventory (planned)**:
+  - `decide` / `native_decide` for finite enumeration of small formats.
+  - `simp` + `simp_arith` for structural lemmas.
+  - `omega`, `linarith`, `norm_num` for arithmetic.
+  - `List` / `Array` induction for round-trips.
+  - `aesop` as a fallback for small but nontrivial goals.
+
+## 6. Open Questions for Maintainers
+
+These are flagged for human input but do not block work:
+
+1. **Endianness of `encode_int`** — the implementation is little-endian
+   (low byte first); should the Lean spec mirror this or use a normalised
+   big-endian representation internally? Default plan: mirror little-endian
+   for direct correspondence.
+2. **`encode_uint16` overflow** — the implementation raises on negative or
+   out-of-range inputs. Lean model will treat the function as a partial
+   function with precondition `0 ≤ n < 2^bits`. Acceptable?
+3. **Transaction fixture scope** — `version3_multi_io.hex` covers
+   `REFERENCES_TX_VERSION` exactly. Round-trip is tested only for that
+   version; we will mirror this scope unless maintainers want broader
+   coverage.
+
+## 7. Reference Material
+
+- [Mixin Network developers docs](https://developers.mixin.one/docs)
+- [bot-api-go-client](https://github.com/MixinNetwork/bot-api-go-client) —
+  parity target, source of golden fixtures
+- [bot-api-nodejs-client](https://github.com/MixinNetwork/bot-api-nodejs-client)
+- Mathlib modules we plan to lean on: `Mathlib.Data.List.Basic`,
+  `Mathlib.Data.ByteArray`, `Mathlib.Tactic.Omega`,
+  `Mathlib.Tactic.Linarith`, `Mathlib.Tactic.Ring`
+
+---
+
+## Last Updated
+- **Date**: 2026-06-15 06:38 UTC
+- **Commit**: `<pending — to be filled when PR is opened>`

--- a/formal-verification/TARGETS.md
+++ b/formal-verification/TARGETS.md
@@ -1,0 +1,75 @@
+# Formal Verification Targets — MixinBot
+
+> 🔬 *Lean Squad — automated formal verification for `baizhiheizi/mixin_bot`.*
+
+**Status**: Initial target list defined. Phase 1 targets ready for spec extraction.
+
+## Convention
+
+Each target row contains:
+
+- **Phase**: current progress (1=research, 2=informal spec, 3=Lean spec, 4=Lean impl, 5=proofs)
+- **Property**: the headline property we want to prove
+- **Effort**: rough proof engineering effort (low/medium/high)
+- **Value**: bug-catching potential (low/medium/high)
+
+## Targets
+
+### Tier 1 — Foundation (small, high tractability, used everywhere)
+
+| Target | File(s) | Phase | Property | Effort | Value |
+|--------|---------|-------|----------|--------|-------|
+| `UUID` round-trip | `lib/mixin_bot/uuid.rb` | 1 | `packed ∘ unpacked = id` and `unpacked ∘ packed = id` (on valid inputs) | low | high |
+| Varint integer codec | `lib/mixin_bot/utils/encoder.rb` (`encode_int`), `lib/mixin_bot/utils/decoder.rb` (`decode_int`) | 1 | `decode_int (encode_int n) = n` for non-negative `n` | low | high |
+| Fixed-width uint codec | same files (`encode_uint16/32/64`, `decode_uint16/32/64`) | 1 | round-trip for `0 ≤ n < 2^bits`; output length is exact `bits/8` | low | high |
+
+### Tier 2 — Address formats (security-sensitive, golden-tested)
+
+| Target | File(s) | Phase | Property | Effort | Value |
+|--------|---------|-------|----------|--------|-------|
+| `MainAddress` round-trip + invariants | `lib/mixin_bot/address.rb` (`MainAddress`) | 1 | `MainAddress.new(public_key:).address` then `MainAddress.new(address:).public_key = original`; address starts with `XIN`, valid base58, valid SHA3-256 checksum | medium | high |
+| `MixAddress` round-trip + invariants | `lib/mixin_bot/address.rb` (`MixAddress`) | 1 | round-trip for valid member lists; address starts with `MIX`; members + threshold + version preserved; `XIN`/UUID members separated correctly | medium | high |
+
+### Tier 3 — Larger formats (builds on Tiers 1+2)
+
+| Target | File(s) | Phase | Property | Effort | Value |
+|--------|---------|-------|----------|--------|-------|
+| `Transaction` round-trip | `lib/mixin_bot/transaction/encoder.rb`, `decoder.rb` | 1 | `decode ∘ encode = id` on the golden hex fixture; magic/version/asset/inputs/outputs/extra/signatures preserved | high | high |
+| `Nfo` (NFT memo) round-trip | `lib/mixin_bot/nfo.rb` | 1 | `decode ∘ encode = id`; mask bit-encoding invariant; UUID packing preserved | medium | medium |
+
+### Tier 4 — Stretch goals
+
+| Target | File(s) | Phase | Property | Effort | Value |
+|--------|---------|-------|----------|--------|-------|
+| `Invoice` round-trip | `lib/mixin_bot/invoice.rb` | 1 | `decode ∘ encode = id` for two-entry invoice golden fixture | medium | medium |
+| `access_token` JWT structure | `lib/mixin_bot/utils/crypto.rb` | 1 | JWT header/payload structure preserved through signing; sig hash matches expected | high | medium |
+| Address sort-order invariant | `lib/mixin_bot/address.rb` (`MixinAddress` constructor) | 1 | members list is sorted by construction | low | low |
+
+## Phasing Plan
+
+- **Run 1 (this run)**: Phase 1 — produce RESEARCH.md (done), TARGETS.md (this
+  file). Set up CI scaffolding.
+- **Run 2**: Tier 1 informal specs → Lean specs → impl → proofs.
+- **Run 3+**: Tier 2.
+- **Run 4+**: Tier 3.
+
+The phasing is heuristic; the squad adapts based on prior-run findings and
+critique feedback.
+
+## Source / Sink Files Map
+
+| Lean file (planned) | Ruby source | Notes |
+|---------------------|-------------|-------|
+| `FVSquad/UUID.lean` | `lib/mixin_bot/uuid.rb` | Hex ↔ raw ↔ dashed-UUID bijection |
+| `FVSquad/Varint.lean` | `lib/mixin_bot/utils/encoder.rb` (`encode_int`, `decode_int`) | Little-endian varint |
+| `FVSquad/UintCodec.lean` | `lib/mixin_bot/utils/encoder.rb` (`encode_uint16/32/64`) | Big-endian fixed-width |
+| `FVSquad/MainAddress.lean` | `lib/mixin_bot/address.rb` (`MainAddress`) | XIN-prefixed |
+| `FVSquad/MixAddress.lean` | `lib/mixin_bot/address.rb` (`MixAddress`) | MIX-prefixed, multi-member |
+| `FVSquad/Transaction.lean` | `lib/mixin_bot/transaction/{encoder,decoder}.rb` | Golden fixture |
+| `FVSquad/Nfo.lean` | `lib/mixin_bot/nfo.rb` | NFT memo encoding |
+
+---
+
+## Last Updated
+- **Date**: 2026-06-15 06:38 UTC
+- **Commit**: `<pending — to be filled when PR is opened>`


### PR DESCRIPTION
- Add formal-verification/RESEARCH.md surveying the Ruby codebase and
  selecting Lean 4 as the prover.
- Add formal-verification/TARGETS.md with a tiered list of 7 FV-amenable
  targets (UUID codec, varint codec, fixed-width uint codec, MainAddress,
  MixAddress, Transaction, Nfo), prioritised by tractability and value.
- Add .github/workflows/lean-ci.yml that activates when Lean source files
  appear under formal-verification/lean/.

🔬 Generated with Lean Squad (https://github.com/baizhiheizi/mixin_bot)
