### PR TITLE
[repo-assist] 📝 docs: bump stale version references from 2.2.1 to 2.3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — MixinBot
 
-Ruby gem (v2.2.1): Mixin Network REST SDK + `mixinbot` CLI. Parity targets: [bot-api-go-client](https://github.com/MixinNetwork/bot-api-go-client), [bot-api-nodejs-client](https://github.com/MixinNetwork/bot-api-nodejs-client).
+Ruby gem (v2.3.0): Mixin Network REST SDK + `mixinbot` CLI. Parity targets: [bot-api-go-client](https://github.com/MixinNetwork/bot-api-go-client), [bot-api-nodejs-client](https://github.com/MixinNetwork/bot-api-nodejs-client).
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**MixinBot** is a Ruby gem (v2.2.1) providing a Ruby SDK and CLI for [Mixin Network](https://developers.mixin.one/docs). It mirrors the official [bot-api-go-client](https://github.com/MixinNetwork/bot-api-go-client) Go SDK and [bot-api-nodejs-client](https://github.com/MixinNetwork/bot-api-nodejs-client) Node SDK.
+**MixinBot** is a Ruby gem (v2.3.0) providing a Ruby SDK and CLI for [Mixin Network](https://developers.mixin.one/docs). It mirrors the official [bot-api-go-client](https://github.com/MixinNetwork/bot-api-go-client) Go SDK and [bot-api-nodejs-client](https://github.com/MixinNetwork/bot-api-nodejs-client) Node SDK.
 
 Key components:
 - **`MixinBot::API`** — REST SDK for Safe UTXO transfers, messaging, assets, inscriptions, etc.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ruby SDK and CLI for [Mixin Network](https://developers.mixin.one/docs): authent
 
 The gem aims for **parity with the official [bot-api-go-client](https://github.com/MixinNetwork/bot-api-go-client)** Go SDK and **[bot-api-nodejs-client](https://github.com/MixinNetwork/bot-api-nodejs-client)** Node SDK. See [API_COVERAGE.md](API_COVERAGE.md) for the full mapping; run `rake mixin_bot:api_coverage` to confirm no gaps are marked missing.
 
-Current gem version: **2.2.1** (see [CHANGELOG.md](CHANGELOG.md) for breaking changes and deprecations).
+Current gem version: **2.3.0** (see [CHANGELOG.md](CHANGELOG.md) for breaking changes and deprecations).
 
 ## Requirements
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # MixinBot
 
-> Ruby SDK and CLI for Mixin Network: Safe UTXO transfers, REST API, Blaze messaging, transaction crypto, optional MVM helpers. Ruby >= 3.2. Gem version 2.2.1.
+> Ruby SDK and CLI for Mixin Network: Safe UTXO transfers, REST API, Blaze messaging, transaction crypto, optional MVM helpers. Ruby >= 3.2. Gem version 2.3.0.
 
 Important notes:
 


### PR DESCRIPTION
The README, llms.txt, AGENTS.md, and CLAUDE.md all referenced '2.2.1'
while lib/mixin_bot/version.rb has been at '2.3.0' since the 2026-05-27
release. Update all four files so the documentation matches the current
gem version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
